### PR TITLE
Make sure you cannot run multiple permission requests at the same time

### DIFF
--- a/ios/Classes/PermissionManager.swift
+++ b/ios/Classes/PermissionManager.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 import Swift
 
+typealias PermissionRequestCompletion = (_ permissionRequestResults: [PermissionGroup:PermissionStatus]) -> ()
+
 class PermissionManager: NSObject {
     private var _strategyInstances: [ObjectIdentifier: PermissionStrategy] = [:]
     
@@ -20,7 +22,7 @@ class PermissionManager: NSObject {
         result(Codec.encodePermissionStatus(permissionStatus: permissionStatus))
     }
     
-    func requestPermission(permissions: [PermissionGroup], result: @escaping FlutterResult) {
+    func requestPermissions(permissions: [PermissionGroup], completion: @escaping PermissionRequestCompletion) {
         var requestQueue = Set(permissions.map { $0 })
         var permissionStatusResult: [PermissionGroup: PermissionStatus] = [:]
         
@@ -35,7 +37,7 @@ class PermissionManager: NSObject {
                 self._strategyInstances.removeValue(forKey: ObjectIdentifier(permissionStrategy as AnyObject))
                 
                 if requestQueue.count == 0 {
-                    result(Codec.encodePermissionRequestResult(permissionStatusResult: permissionStatusResult))
+                    completion(permissionStatusResult)
                     return
                 }
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On iOS it is possible to run multiple requests for permissions at the same time. This doesn't match with the Android API

### :new: What is the new behavior (if this is a feature change)?

The plugin will throw an exception when you send a second request for permissions while the first request is not yet finished.

### :boom: Does this PR introduce a breaking change?

Nope

### :bug: Recommendations for testing

Run example app

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop