### PR TITLE
Converted plugin to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies:
 ``` dart
 import 'package:permission_handler/permission_handler.dart';
 
-Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().requestPermissions(PermissionGroup.Contacts);
+Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler.requestPermissions([PermissionGroup.contacts]);
 ```
 
 ### Checking permission
@@ -42,7 +42,7 @@ Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler().r
 ``` dart
 import 'package:permission_handler/permission_handler.dart';
 
-PermissionStatus permission = await PermissionHandler().checkPermissionStatus(PermissionGroup.Contacts);
+PermissionStatus permission = await PermissionHandler.checkPermissionStatus(PermissionGroup.contacts);
 ```
 
 ### Open app settings
@@ -50,7 +50,7 @@ PermissionStatus permission = await PermissionHandler().checkPermissionStatus(Pe
 ``` dart
 import 'package:permission_handler/permission_handler.dart';
 
-bool isOpened = await PermissionHandler().openAppSettings();
+bool isOpened = await PermissionHandler.openAppSettings();
 ```
 
 ### Show a rationale for requesting permission (Android only)
@@ -58,7 +58,7 @@ bool isOpened = await PermissionHandler().openAppSettings();
 ``` dart
 import 'package:permission_handler/permission_handler.dart';
 
-bool isShown = await PermissionHandler().shouldShowRequestPermissionRationale(PermissionGroup.Contacts);
+bool isShown = await PermissionHandler.shouldShowRequestPermissionRationale(PermissionGroup.contacts);
 ```
 
 This will always return `false` on iOS.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_enums.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 void main() => runApp(new MyApp());

--- a/lib/permission_enums.dart
+++ b/lib/permission_enums.dart
@@ -1,3 +1,5 @@
+part of permission_handler;
+
 /// Defines the state of a permission group
 enum PermissionStatus {
   /// Permission to access the requested feature is denied by the user.

--- a/lib/permission_handler.dart
+++ b/lib/permission_handler.dart
@@ -1,9 +1,13 @@
+library permission_handler;
+
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:permission_handler/permission_enums.dart';
-import 'package:permission_handler/utils/codec.dart';
+
+part 'package:permission_handler/permission_enums.dart';
+part 'package:permission_handler/utils/codec.dart';
 
 /// Provides a cross-platform (iOS, Android) API to request and check permissions.
 class PermissionHandler {

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -1,6 +1,4 @@
-import 'dart:convert';
-
-import 'package:permission_handler/permission_enums.dart';
+part of permission_handler;
 
 class Codec {
   static PermissionStatus decodePermissionStatus(dynamic value) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

In current version you separately have to import `permission_enums.dart` to get access to the `PermissionGroup` and `PermissionStatus` enums. 

### :new: What is the new behavior (if this is a feature change)?

By converting the project into a library (using the `library`, `part` and `part of` keywords) this will no longer be necessary and the user now only needs to import the `permission_handler.dart`.

### :boom: Does this PR introduce a breaking change?

Yes (developers using the plugin need to remove the existing `import 'package:permission_handler/permission_enums.dart';` line from their code to be able to compile again.

### :bug: Recommendations for testing

Run the example application:

```shell
# Change into the example folder
cd example
# Run the example application
flutter run
```

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop