### PR TITLE
Bump version number and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+* Converted the plugin into a library so that developers don't have to import additional files;
+* Updated the README.md to fix example code.
+
 ## 1.0.0
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use this plugin, add `permission_handler` as a [dependency in your pubspec.ya
 
 ```yaml
 dependencies:
-  permission_handler: '^1.0.0'
+  permission_handler: '^1.0.1'
 ```
 
 > **NOTE:** There's a known issue with integrating plugins that use Swift into a Flutter project created with the Objective-C template. See issue [Flutter#16049](https://github.com/flutter/flutter/issues/16049) for help on integration.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,7 +96,7 @@ class _PermissionState extends State<PermissionWidget> {
         style: new TextStyle(color: getPermissionColor()),
       ),
       onTap: () async {
-        requestPermission(_permissionGroup); 
+        requestPermission(_permissionGroup);
       },
     );
   }

--- a/ios/permission_handler.podspec
+++ b/ios/permission_handler.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'permission_handler'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'Permission plugin for Flutter.'
   s.description      = <<-DESC
 Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.

--- a/lib/permission_handler.dart
+++ b/lib/permission_handler.dart
@@ -49,8 +49,7 @@ class PermissionHandler {
   /// returns [false].
   static Future<bool> shouldShowRequestPermissionRationale(
       PermissionGroup permission) async {
-
-    if (!Platform.isAndroid) { 
+    if (!Platform.isAndroid) {
       return false;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 1.0.0
+version: 1.0.1
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-permission-handler
 


### PR DESCRIPTION
Prepare for version 1.0.1:

- Update version numbers
- Update Changelog
- Fix code formatting (as reported on pub.dartlang.org)