### PR TITLE
Fix error with dependency on Android Support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,8 @@ android {
 }
 
 dependencies {
+    api "com.android.support:support-compat:27.1.1"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.8.5"
-    implementation "com.android.support:support-compat:27.1.1"
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix (Android only)

### :arrow_heading_down: What is the current behavior?

When including other libraries which reference a different version of the `com.android.support:support-compat` package the application won't compile.

### :new: What is the new behavior (if this is a feature change)?

Fixed configuration in gradle file to prevent these kind of errors.

### :boom: Does this PR introduce a breaking change?

Nope

### :bug: Recommendations for testing

Run the example project

### :memo: Links to relevant issues/docs

- Fixes #28 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop