### PR TITLE
Put the swift version in the podspec so that users don't have to over…

### DIFF
--- a/ios/permission_handler.podspec
+++ b/ios/permission_handler.podspec
@@ -17,5 +17,6 @@ Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Andro
   s.dependency 'Flutter'
   
   s.ios.deployment_target = '8.0'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 end
 


### PR DESCRIPTION
…ride it in their podfile post install.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Podspec update.

### :arrow_heading_down: What is the current behavior?

Currently, users of this plugin have to override their podfile's post install to set the swift version for all pods. This is error prone and shouldn't be necessary since we can include the swift version in the podspec.

### :new: What is the new behavior (if this is a feature change)?

Users can use this plugin out of the box without having to change their podfile.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/flutter/flutter/issues/16049

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop