### PR TITLE
Fix build error on latest Xcode (iOS 12)

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -60,6 +60,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['ENABLE_BITCODE'] = 'NO'
+      config.build_settings['SWIFT_VERSION'] = '4.2'
     end
   end
 end

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -417,6 +418,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/ios/Classes/PermissionManager.swift
+++ b/ios/Classes/PermissionManager.swift
@@ -47,10 +47,14 @@ class PermissionManager: NSObject {
     static func openAppSettings(result: @escaping FlutterResult) {
         if #available(iOS 8.0, *) {
             if #available(iOS 10, *) {
-                UIApplication.shared.open(URL.init(string: UIApplication.openSettingsURLString)!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]),
-                                          completionHandler: {
-                                            (success) in result(success)
-                                          })
+                guard let url = URL(string: UIApplication.openSettingsURLString),
+                    UIApplication.shared.canOpenURL(url) else {
+                        return
+                }
+                
+                let optionsKeyDictionary = [UIApplication.OpenExternalURLOptionsKey(rawValue: "universalLinksOnly"): NSNumber(value: true)]
+                
+                UIApplication.shared.open(url, options: optionsKeyDictionary, completionHandler: nil)
             } else {
                 let success = UIApplication.shared.openURL(URL.init(string: UIApplication.openSettingsURLString)!)
                 result(success)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug

### :arrow_heading_down: What is the current behavior?

Apple introduced a breaking change in the latest version of iOS SDK, causing the build to fail.

### :new: What is the new behavior (if this is a feature change)?

Correctly call the iOS SDK so the build doesn't fail anymore.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example project

### :memo: Links to relevant issues/docs

- Fixes #49 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop