### PR TITLE
Fix compilation when trying to build iOS targets (Swift 4.2 | XCode 10.1)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -111,7 +111,6 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors

--- a/ios/Classes/PermissionManager.swift
+++ b/ios/Classes/PermissionManager.swift
@@ -47,16 +47,13 @@ class PermissionManager: NSObject {
     static func openAppSettings(result: @escaping FlutterResult) {
         if #available(iOS 8.0, *) {
             if #available(iOS 10, *) {
-                guard let url = URL(string: UIApplication.openSettingsURLString),
+                guard let url = URL(string: UIApplicationOpenSettingsURLString),
                     UIApplication.shared.canOpenURL(url) else {
                         return
                 }
-                
-                let optionsKeyDictionary = [UIApplication.OpenExternalURLOptionsKey(rawValue: "universalLinksOnly"): NSNumber(value: true)]
-                
-                UIApplication.shared.open(url, options: optionsKeyDictionary, completionHandler: nil)
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else {
-                let success = UIApplication.shared.openURL(URL.init(string: UIApplication.openSettingsURLString)!)
+                let success = UIApplication.shared.openURL(URL.init(string: UIApplicationOpenSettingsURLString)!)
                 result(success)
             }
         }
@@ -92,9 +89,4 @@ class PermissionManager: NSObject {
             return UnknownPermissionStrategy()
         }
     }
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToUIApplicationOpenExternalURLOptionsKeyDictionary(_ input: [String: Any]) -> [UIApplication.OpenExternalURLOptionsKey: Any] {
-	return Dictionary(uniqueKeysWithValues: input.map { key, value in (UIApplication.OpenExternalURLOptionsKey(rawValue: key), value)})
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix (iOS compilation errors)

### :arrow_heading_down: What is the current behavior?

When users try to include the latest tagged version (2.1.2) in their Flutter projects and try to run the app on an iOS device or simulator, XCode generates several compilation errors related to using deprecated APIs to open the Settings app.

### :new: What is the new behavior (if this is a feature change)?

Fixes #57 (https://github.com/BaseflowIT/flutter-permission-handler/issues/57) + does not require users to update their podfile manually

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example app or include this branch in one of your Flutter projects

### :memo: Links to relevant issues/docs

Fixes #57 (https://github.com/BaseflowIT/flutter-permission-handler/issues/57) + does not require users to update their `podfile` manually

### :thinking: Checklist before submitting

- [x ] All projects build
- [x ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x ] Relevant documentation was updated
- [x ] Rebased onto current develop