### PR TITLE
specify the swift version

### DIFF
--- a/ios/permission_handler.podspec
+++ b/ios/permission_handler.podspec
@@ -15,7 +15,7 @@ Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Andro
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
+  s.swift_version = '4.2'
   s.ios.deployment_target = '8.0'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 end


### PR DESCRIPTION
Specify the swift version to avoid compile error when use cocoapods 1.6
