### PR TITLE
Make sure permission result matches requested group

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -366,6 +366,9 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         continue;
 
       if (permission == PERMISSION_GROUP_MICROPHONE) {
+        if (!mRequestResults.containsKey(PERMISSION_GROUP_MICROPHONE)) {
+          mRequestResults.put(PERMISSION_GROUP_MICROPHONE, toPermissionStatus(grantResults[i]));
+        }
         if (!mRequestResults.containsKey(PERMISSION_GROUP_SPEECH)) {
           mRequestResults.put(PERMISSION_GROUP_SPEECH, toPermissionStatus(grantResults[i]));
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When requesting permissions for the `PermissionGroup.microphone` on Android the result returned is based on the `PermissionGroup.speech`.

### :new: What is the new behavior (if this is a feature change)?

Updated the code so the result is based on `PermissionGroup.microphone` and `PermissionGroup.speech`.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example application.

### :memo: Links to relevant issues/docs

- Fixes #67 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop