### PR TITLE
Clarify PermissionStatus.restricted description.

### DIFF
--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -13,7 +13,9 @@ class PermissionStatus {
   /// Permission to access the requested feature is granted by the user.
   static const PermissionStatus granted = PermissionStatus._(2);
 
-  /// The user granted restricted access to the requested feature (only on iOS).
+  /// Permission to access the requested feature is denied by the OS (only on iOS).
+  /// The user cannot change this app's status, possibly due to active restrictions such as
+  /// parental controls being in place.
   static const PermissionStatus restricted = PermissionStatus._(3);
 
   /// Permission is in an unknown state


### PR DESCRIPTION
Changing description from incorrect "user granted restricted access" to the description found on the Apple Developer site:
"kCLAuthorizationStatusRestricted
This app is not authorized to use location services.
The user cannot change this app’s status, possibly due to active restrictions such as parental controls being in place."
https://developer.apple.com/documentation/corelocation/clauthorizationstatus/kclauthorizationstatusrestricted

This is my first git pull request.  Please be kind. :)

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update.


### :arrow_heading_down: What is the current behavior?
Misleading description.

### :new: What is the new behavior (if this is a feature change)?
More clear description.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
No special testing required.  Only a comment is changed.

### :memo: Links to relevant issues/docs
See description above.


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop