### PR TITLE
Remove print statement

### DIFF
--- a/lib/src/utils/codec.dart
+++ b/lib/src/utils/codec.dart
@@ -11,7 +11,6 @@ class Codec {
 
   static Map<PermissionGroup, PermissionStatus> decodePermissionRequestResult(
       Map<int, int> value) {
-    print('decodePermissionRequestResult called with: value:[$value]');
     return value.map((int key, int value) =>
         MapEntry<PermissionGroup, PermissionStatus>(
             PermissionGroup.values[key], PermissionStatus.values[value]));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code maintenance

### :arrow_heading_down: What is the current behavior?
Prints call arguments when `decodePermissionRequestResult` is called.

### :new: What is the new behavior (if this is a feature change)?
Does not print call arguments when `decodePermissionRequestResult` is called.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop