### PR TITLE
Android uses request code 24 from now on

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -33,7 +33,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class PermissionHandlerPlugin implements MethodCallHandler {
   private static final String LOG_TAG = "permissions_handler";
-  private static final int PERMISSION_CODE = 25;
+  private static final int PERMISSION_CODE = 24;
 
   //PERMISSION_GROUP
   private static final int PERMISSION_GROUP_CALENDAR = 0;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

To prevent issues with the location_permissions plugin, as it's being used from geolocator.

### :arrow_heading_down: What is the current behavior?

Conflicts with location_permissions.. details in #111 

### :new: What is the new behavior (if this is a feature change)?

Change request code.

### :bug: Recommendations for testing

include geolcoator in example - test permissions like call or storage,

### :memo: Links to relevant issues/docs

Consider to set proper request codes for all BaseflowIT plugins to avoid any further conflicts.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop