### PR TITLE
Repair error logging

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -251,14 +251,14 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
     final List<String> names = getManifestNames(permission);
 
     if (names == null) {
-      Log.d(LOG_TAG, "No android specific permissions needed for: $permission");
+      Log.d(LOG_TAG, "No android specific permissions needed for: " + permission);
 
       return PERMISSION_STATUS_GRANTED;
     }
 
     //if no permissions were found then there is an issue and permission is not set in Android manifest
     if (names.size() == 0) {
-      Log.d(LOG_TAG, "No permissions found in manifest for: $permission");
+      Log.d(LOG_TAG, "No permissions found in manifest for: " + permission);
       return PERMISSION_STATUS_UNKNOWN;
     }
 
@@ -364,12 +364,12 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
 
     // if isn't an android specific group then go ahead and return false;
     if (names == null) {
-      Log.d(LOG_TAG, "No android specific permissions needed for: $permission");
+      Log.d(LOG_TAG, "No android specific permissions needed for: " + permission);
       return false;
     }
 
     if (names.isEmpty()) {
-      Log.d(LOG_TAG, "No permissions found in manifest for: $permission no need to show request rationale");
+      Log.d(LOG_TAG, "No permissions found in manifest for: " + permission + " no need to show request rationale");
       return false;
     }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix.

### :arrow_heading_down: What is the current behavior?

When a permission request fails, an invalid log message is produced.
This seems to be a artifact from the Kotlin implementation which supported inline string formatting.

### :new: What is the new behavior (if this is a feature change)?

Error logs do not contain `$permission` but the correct permission name.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Introduce errors to example app and check the logs.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop