### PR TITLE
Removed redundant gradle wrapper

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Wed Feb 13 12:10:05 CET 2019
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Plugin restricts consuming applications to use gradle-wrapper version 4.10.1. 

### :new: What is the new behavior (if this is a feature change)?

Plugin should no longer be restricted to a specific gradle wrapper version.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Create a new Flutter App and make sure you use a gradle version bigger then 4.10.1 (e.g. 5.1.1), take a reference to the `permission_handler` plugin in you pubspec.yaml file and try to compile the Android application: `flutter build apk`

### :memo: Links to relevant issues/docs

#136 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop