### PR TITLE
Fixed deprecated permissions

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -182,7 +182,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       case Manifest.permission.WRITE_CALL_LOG:
       case Manifest.permission.ADD_VOICEMAIL:
       case Manifest.permission.USE_SIP:
-      case Manifest.permission.PROCESS_OUTGOING_CALLS:
+      case Manifest.permission.BIND_CALL_REDIRECTION_SERVICE:
         return PERMISSION_GROUP_PHONE;
       case Manifest.permission.BODY_SENSORS:
         return PERMISSION_GROUP_SENSORS;
@@ -620,8 +620,9 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         if (hasPermissionInManifest(Manifest.permission.USE_SIP))
           permissionNames.add(Manifest.permission.USE_SIP);
 
-        if (hasPermissionInManifest(Manifest.permission.PROCESS_OUTGOING_CALLS))
-          permissionNames.add(Manifest.permission.PROCESS_OUTGOING_CALLS);
+        if (hasPermissionInManifest(Manifest.permission.BIND_CALL_REDIRECTION_SERVICE))
+          permissionNames.add(Manifest.permission.BIND_CALL_REDIRECTION_SERVICE);
+
         break;
 
       case PERMISSION_GROUP_SENSORS:

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
     <uses-permission android:name="android.permission.USE_SIP"/>
     <uses-permission android:name="android.permission.READ_CALL_LOG"/>
     <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
-    <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS"/>
+    <uses-permission android:name="android.permission.BIND_CALL_REDIRECTION_SERVICE"/>
 
     <!-- Permissions options for the `calendar` group -->
     <uses-permission android:name="android.permission.READ_CALENDAR" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When compiling against API 29 a the compiler warns / fails because the permission `PROCESS_OUTGOING_CALLS` have been deprecated by Google.

### :new: What is the new behavior (if this is a feature change)?

Instead of requesting the `PROCESS_OUTGOING_CALLS ` permissions, the plugin is now requesting the `BIND_CALL_REDIRECTION_SERVICE` permission as suggested by [Google here](https://developer.android.com/reference/android/Manifest.permission.html#PROCESS_OUTGOING_CALLS).

### :boom: Does this PR introduce a breaking change?

Yes. This code will not compile when running against a target API below 29.

### :bug: Recommendations for testing

Run the example test/

### :memo: Links to relevant issues/docs

- fixes #167 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop