### PR TITLE
Adds support for StoragePermissionStrategy on iOS

### DIFF
--- a/ios/Classes/PermissionManager.h
+++ b/ios/Classes/PermissionManager.h
@@ -19,6 +19,7 @@
 #import "PhotoPermissionStrategy.h"
 #import "SensorPermissionStrategy.h"
 #import "SpeechPermissionStrategy.h"
+#import "StoragePermissionStrategy.h"
 #import "UnknownPermissionStrategy.h"
 #import "PermissionHandlerEnums.h"
 #import "Codec.h"
@@ -28,13 +29,10 @@ typedef void (^PermissionRequestCompletion)(NSDictionary *permissionRequestResul
 @interface PermissionManager : NSObject
 
 - (instancetype)initWithStrategyInstances;
+- (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion;
 
 + (void)checkPermissionStatus:(enum PermissionGroup)permission result:(FlutterResult)result;
-
 + (void)checkServiceStatus:(enum PermissionGroup)permission result:(FlutterResult)result;
-
 + (void)openAppSettings:(FlutterResult)result;
-
-- (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion;
 
 @end

--- a/ios/Classes/PermissionManager.m
+++ b/ios/Classes/PermissionManager.m
@@ -75,30 +75,32 @@
 
 + (id)createPermissionStrategy:(PermissionGroup)permission {
     switch (permission) {
-            case PermissionGroupCalendar:
+        case PermissionGroupCalendar:
             return [EventPermissionStrategy new];
-            case PermissionGroupCamera:
+        case PermissionGroupCamera:
             return [AudioVideoPermissionStrategy new];
-            case PermissionGroupContacts:
+        case PermissionGroupContacts:
             return [ContactPermissionStrategy new];
-            case PermissionGroupLocation:
-            case PermissionGroupLocationAlways:
-            case PermissionGroupLocationWhenInUse:
+        case PermissionGroupLocation:
+        case PermissionGroupLocationAlways:
+        case PermissionGroupLocationWhenInUse:
             return [[LocationPermissionStrategy alloc] initWithLocationManager];
-            case PermissionGroupMediaLibrary:
+        case PermissionGroupMediaLibrary:
             return [MediaLibraryPermissionStrategy new];
-            case PermissionGroupMicrophone:
+        case PermissionGroupMicrophone:
             return [AudioVideoPermissionStrategy new];
-            case PermissionGroupPhone:
+        case PermissionGroupPhone:
             return [PhonePermissionStrategy new];
-            case PermissionGroupPhotos:
+        case PermissionGroupPhotos:
             return [PhotoPermissionStrategy new];
-            case PermissionGroupReminders:
+        case PermissionGroupReminders:
             return [EventPermissionStrategy new];
-            case PermissionGroupSensors:
+        case PermissionGroupSensors:
             return [SensorPermissionStrategy new];
-            case PermissionGroupSpeech:
+        case PermissionGroupSpeech:
             return [SpeechPermissionStrategy new];
+        case PermissionGroupStorage:
+            return [StoragePermissionStrategy new];
         default:
             return [UnknownPermissionStrategy new];
     }

--- a/ios/Classes/strategies/StoragePermissionStrategy.h
+++ b/ios/Classes/strategies/StoragePermissionStrategy.h
@@ -1,0 +1,17 @@
+//
+//  StoragePermissionStrategy.h
+//  permission_handler
+//
+//  Created by Frank Gregor on 06.11.19.
+//
+
+#import <Foundation/Foundation.h>
+#import "PermissionStrategy.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface StoragePermissionStrategy : NSObject <PermissionStrategy>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classes/strategies/StoragePermissionStrategy.m
+++ b/ios/Classes/strategies/StoragePermissionStrategy.m
@@ -1,0 +1,28 @@
+//
+//  StoragePermissionStrategy.m
+//  permission_handler
+//
+//  Created by Frank Gregor on 06.11.19.
+//
+
+#import "StoragePermissionStrategy.h"
+
+@implementation StoragePermissionStrategy
+
+- (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
+    return [StoragePermissionStrategy permissionStatus];
+}
+
+- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+    return ServiceStatusNotApplicable;
+}
+
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+    completionHandler([StoragePermissionStrategy permissionStatus]);
+}
+
++ (PermissionStatus)permissionStatus {
+    return PermissionStatusGranted;
+}
+
+@end

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -142,7 +142,7 @@ class PermissionGroup {
   static const PermissionGroup speech = PermissionGroup._(13);
 
   /// Android: External Storage
-  /// iOS: Nothing
+  /// iOS: Access to folders like `Documents` or `Downloads`. Implicitly granted.
   static const PermissionGroup storage = PermissionGroup._(14);
 
   /// Android: Ignore Battery Optimizations


### PR DESCRIPTION
#### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds the missing `StoragePermissionStrategy` for iOS only. For example, it is needed to store files in the `Documents` folder. Without this stategy permission is currently denied on request.

#### :arrow_heading_down: What is the current behavior?
Permission is denied on request.  
Special permission on writing into directories like `Documents` or `Downloads` isn't required since every app runs in its own sandbox. Permission is implicitly granted.

#### :new: What is the new behavior (if this is a feature change)?
Permission is automatically granted on request.

#### :boom: Does this PR introduce a breaking change?
No

#### :bug: Recommendations for testing
No

#### :memo: Links to relevant issues/docs
None

#### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop